### PR TITLE
docs: add docs/ and examples/

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,95 @@
+# Advanced
+
+Recipes and edges beyond the basic lookups. All snippets use only the public API
+and the packaged data.
+
+## Build a grapheme-to-phoneme map for a model
+
+`get_ipa_map()` hands you a flat `{word: phonemes}` dictionary for one POS and
+region — exactly the shape a G2P training step or a TTS front-end wants.
+
+```python
+from tugalex import TugaLexicon
+
+lex = TugaLexicon()
+nouns = lex.get_ipa_map(pos="NOUN", region="lbx")
+verbs = lex.get_ipa_map(pos="VERB", region="lbx")
+print(len(nouns), len(verbs))   # tens of thousands each
+```
+
+Need every POS for every word? Walk `possible_postags`:
+
+```python
+for word, tags in list(lex.possible_postags.items())[:5]:
+    for tag in tags:
+        print(word, tag, lex.get_phonemes(word, pos=tag))
+```
+
+## Resolve homographs correctly
+
+A homograph carries a different transcription per POS, and the homograph table is
+consulted before the regional dictionary. Always pass the POS you mean:
+
+```python
+lex.get_phonemes("para", pos="ADP")    # ˈpɐɾɐ  (the preposition "for")
+lex.get_phonemes("para", pos="VERB")   # ˈpaɾɐ  (he/she stops)
+```
+
+The full table is `lex.homographs` — `{word: {POS: ipa}}`.
+
+## Archaisms fold into pronunciation automatically
+
+When you ask for the phonemes of a pre-20th-century spelling, it is rewritten to
+its modern form first, so you still get a transcription:
+
+```python
+lex.archaic_words["pharmacia"]      # 'farmácia'
+lex.get_phonemes("architecto")      # 'ɐɾ·ki·tˈɛ·tu'  (looked up as arquiteto)
+```
+
+## Round-trip orthography across the AO1990 agreement
+
+`normalize_ao1900()` goes old → modern; the two `reverse_*` methods go modern →
+old for each standard. Unmapped words pass through, so whole sentences are safe.
+
+```python
+modern = lex.normalize_ao1900("acção óptimo")   # 'ação ótimo'
+back_pt = lex.reverse_ao1900_pt("ótimo")         # 'óptimo'
+```
+
+PT and BR diverge: a word can revert differently per standard, which is why there
+are two reverse methods rather than one.
+
+## Detect spelling phenomena
+
+Two cached sets expose AO1990-related phenomena directly:
+
+```python
+sorted(lex.silent_p_words)[:3]    # words with a silent p, e.g. 'assimptota'
+sorted(lex.voiced_u_words)[:3]    # words that used to carry the trema ü
+```
+
+Use them to flag tokens that need special attention in a pronunciation or
+spell-checking pipeline.
+
+## Gotchas
+
+- **POS casing.** Lookups expect uppercase tags (`NOUN`, `VERB`, `ADJ`, `ADP`).
+  A lowercase tag silently misses and you get `None`.
+- **Unknown words return falsy, they do not raise.** `get_phonemes` returns
+  `None` and `get_syllables` returns `[]` for words not in the dataset. An
+  unsupported *region*, by contrast, raises `ValueError` from `get_syllables`,
+  `get_wordlist`, `get_ipa_map`, and `lang_to_region`.
+- **First touch is slow.** The first access to `ipa`, `syllables`, `regions`, or
+  any method that uses them parses the large CSV. Construct one `TugaLexicon` and
+  reuse it across calls.
+- **More regions than the five public dialects.** `lex.regions` also contains
+  internal codes such as `rjo`, `lbn`, `spx`, `map`, `spo`. Only the five in
+  `lang_to_region` have ISO aliases; the rest are reachable by raw `region=`.
+- **Method names read `1900`.** `normalize_ao1900` / `reverse_ao1900_pt` /
+  `reverse_ao1900_br` implement the AO1990 agreement.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and the core idea
+- [api.md](api.md) — full signatures and return shapes

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,154 @@
+# API reference
+
+The whole library is one class.
+
+```python
+from tugalex import TugaLexicon
+```
+
+## `TugaLexicon(dictionary_path=None)`
+
+| Arg | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `dictionary_path` | `Optional[str]` | `None` | Path to a regional CSV. `None` uses the packaged `data/regional_dict.csv`. |
+
+Construction loads the small CSVs eagerly (AO1990 PT/BR, homographs, archaisms).
+The large `regional_dict.csv` is loaded lazily on first access to phonemes,
+syllables, or regions, then cached on the instance.
+
+### Region codes
+
+ISO dialect codes map to internal region codes through `lang_to_region()`:
+
+| ISO | Region |
+| --- | --- |
+| `pt-PT` | `lbx` |
+| `pt-BR` | `rjx` |
+| `pt-AO` | `lda` |
+| `pt-MZ` | `mpx` |
+| `pt-TL` | `dli` |
+
+The dataset itself carries more regions than the five mapped above (for example
+`rjo`, `lbn`, `spx`, `map`, `spo`); inspect `lex.regions` for the full set. Pass
+any of those raw codes as `region=`.
+
+## Lookup methods
+
+### `get(word, pos="NOUN", region="lbx") -> dict`
+
+Both syllables and phonemes in one call.
+
+```python
+lex.get("acordo", pos="NOUN", region="lbx")
+# {'syllables': ['a', 'cor', 'do'], 'phonemes': 'ɐˈkoɾdu'}
+```
+
+Returns a dict with keys `"syllables"` (`List[str]`, empty if unknown) and
+`"phonemes"` (`Optional[str]`, `None` if unknown).
+
+### `get_phonemes(word, pos="NOUN", region="lbx") -> Optional[str]`
+
+The IPA transcription, or `None` when there is no entry. Matching is
+case-insensitive. Lookup order:
+
+1. If the word is an archaism, it is first rewritten to its modern form.
+2. If the word is a heterophonic homograph with an entry for `pos`, that
+   pronunciation wins (homographs are region-independent).
+3. Otherwise the regional dictionary is consulted for `region` + `pos`.
+
+```python
+lex.get_phonemes("acordo", pos="NOUN")   # 'ɐˈkoɾdu'
+lex.get_phonemes("acordo", pos="VERB")   # 'ɐˈkɔɾdu'
+lex.get_phonemes("architecto")           # 'ɐɾ·ki·tˈɛ·tu'  (archaism -> arquiteto)
+```
+
+### `get_syllables(word, region="lbx") -> List[str]`
+
+Syllable segments for the word; empty list if unknown. Raises `ValueError` if
+`region` is not in the loaded dataset.
+
+```python
+lex.get_syllables("casa")    # ['ca', 'sa']
+```
+
+### `get_wordlist(region="lbx") -> List[str]`
+
+Every word available for a region, sorted. Raises `ValueError` for an unknown
+region.
+
+```python
+len(lex.get_wordlist("lbx"))   # 53349
+```
+
+### `get_ipa_map(pos="NOUN", region="lbx") -> Dict[str, str]`
+
+A flat `{word: phonemes}` map for one POS and region, merging the regional
+dictionary with the homograph table. Raises `ValueError` for an unknown region.
+
+```python
+g2p = lex.get_ipa_map(pos="NOUN")
+len(g2p)              # 32281
+g2p["acordo"]         # 'ɐˈkoɾdu'
+```
+
+### `lang_to_region(lang) -> str`
+
+Map an ISO dialect code to its region code. Raises `ValueError` for an
+unsupported dialect.
+
+```python
+lex.lang_to_region("pt-BR")   # 'rjx'
+```
+
+## Orthographic agreement (AO1990)
+
+### `normalize_ao1900(sentence) -> str`
+
+Rewrite each word to its modern AO1990 spelling; unknown words pass through.
+
+```python
+lex.normalize_ao1900("acção óptimo")   # 'ação ótimo'
+```
+
+### `reverse_ao1900_pt(sentence) -> str`
+
+Modern spelling back to pre-agreement PT-PT.
+
+```python
+lex.reverse_ao1900_pt("ótimo")   # 'óptimo'
+```
+
+### `reverse_ao1900_br(sentence) -> str`
+
+Modern spelling back to pre-agreement PT-BR.
+
+```python
+lex.reverse_ao1900_br("ato")   # 'ato'
+```
+
+## Properties and cached views
+
+| Name | Type | Meaning |
+| --- | --- | --- |
+| `ipa` | `Dict[region, Dict[word, Dict[POS, str]]]` | Lazy IPA map. |
+| `syllables` | `Dict[region, Dict[word, List[str]]]` | Lazy syllable map. |
+| `regions` | `Set[str]` | All region codes present in the loaded dataset. |
+| `homographs` | `Dict[word, Dict[POS, str]]` | POS-dependent pronunciations. |
+| `archaic_words` | `Dict[old, new]` | Pre-20th-century spelling to modern. |
+| `possible_postags` | `Dict[word, List[str]]` | POS tags available per word (cached). |
+| `AO1990` | `Dict[old, List[str]]` | Combined PT + BR old→new spelling map (cached). |
+| `silent_p_words` | `Set[str]` | Words with a silent `p` (`mpc`/`mpç`/`mpt` clusters) (cached). |
+| `voiced_u_words` | `Set[str]` | Words where `u` is voiced in `gue`/`gui`/`que`/`qui` (former trema) (cached). |
+
+```python
+sorted(lex.regions)            # ['dli', 'lbn', 'lbx', 'lda', 'map', ...]
+len(lex.AO1990)                # 3923
+len(lex.silent_p_words)        # 15
+len(lex.voiced_u_words)        # 283
+lex.possible_postags["acordo"] # ['NOUN', 'VERB']
+```
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first calls
+- [advanced.md](advanced.md) — recipes, gotchas, integration

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart — zero to hero
+
+`tugalex` is a lexicon handler for Portuguese dialects. One class, `TugaLexicon`,
+answers three kinds of question about a Portuguese word: how is it pronounced
+(IPA), how does it break into syllables, and how does it spell across the AO1990
+orthographic agreement. All data ships in the package as CSV — no network, no
+model files, no API keys.
+
+## 1. Install
+
+```bash
+pip install -e .
+```
+
+There are no third-party runtime dependencies. The datasets live under
+`tugalex/data/`; `regional_dict.csv` is the large one (~49 MB) and loads lazily
+the first time you touch phonemes, syllables, or regions.
+
+## 2. The one thing to understand
+
+Everything hangs off a single object. Construct it once and reuse it — the heavy
+CSV is parsed on first access and cached on the instance.
+
+```python
+from tugalex import TugaLexicon
+
+lex = TugaLexicon()
+
+info = lex.get("acordo", pos="NOUN", region="lbx")
+print(info)   # {'syllables': ['a', 'cor', 'do'], 'phonemes': 'ɐˈkoɾdu'}
+```
+
+`get()` is the convenience call. Under it sit two focused lookups —
+`get_syllables()` and `get_phonemes()` — which you can call directly when you
+only need one half.
+
+## 3. Part-of-speech matters
+
+Portuguese has heterophonic homographs: same spelling, different sound depending
+on the grammatical role. Pass the right `pos` and you get the right vowel.
+
+```python
+print(lex.get_phonemes("acordo", pos="NOUN"))   # ɐˈkoɾdu  (the noun: an accord)
+print(lex.get_phonemes("acordo", pos="VERB"))   # ɐˈkɔɾdu  (the verb: I wake up)
+```
+
+POS tags are uppercase Universal-Dependencies style: `NOUN`, `VERB`, `ADJ`,
+`ADP`, and so on. Ask a word which tags it carries with
+`lex.possible_postags["acordo"]` → `['NOUN', 'VERB']`.
+
+## 4. Pick a dialect
+
+The dataset is region-indexed. Public ISO dialect codes map to internal region
+codes via `lang_to_region()`:
+
+```python
+lex.lang_to_region("pt-PT")   # 'lbx'  (Portugal)
+lex.lang_to_region("pt-BR")   # 'rjx'  (Brazil)
+```
+
+| ISO code | Region | Place |
+| --- | --- | --- |
+| `pt-PT` | `lbx` | Portugal |
+| `pt-BR` | `rjx` | Brazil |
+| `pt-AO` | `lda` | Angola |
+| `pt-MZ` | `mpx` | Mozambique |
+| `pt-TL` | `dli` | Timor-Leste |
+
+Pass the region code straight into the lookups:
+
+```python
+lex.get_phonemes("acordo", pos="NOUN", region="rjx")
+```
+
+## 5. Orthographic agreement (AO1990)
+
+Convert between pre-agreement and modern spelling in both directions:
+
+```python
+lex.normalize_ao1900("acção óptimo")    # 'ação ótimo'   (old -> modern)
+lex.reverse_ao1900_pt("ótimo")          # 'óptimo'        (modern -> old PT-PT)
+lex.reverse_ao1900_br("ato")            # 'ato'           (modern -> old PT-BR)
+```
+
+Words with no mapping pass through unchanged, so it is safe to run on whole
+sentences.
+
+## Where next
+
+- [api.md](api.md) — every public class, method, kwarg, and return shape
+- [advanced.md](advanced.md) — recipes, gotchas, building grapheme-to-phoneme maps

--- a/examples/01_lookup.py
+++ b/examples/01_lookup.py
@@ -1,0 +1,21 @@
+"""Example — phonemes and syllables for a Portuguese word.
+
+Run::
+
+    python examples/01_lookup.py
+"""
+from tugalex import TugaLexicon
+
+
+def main() -> None:
+    lex = TugaLexicon()
+
+    for word in ["acordo", "casa", "trabalho", "coração"]:
+        info = lex.get(word, pos="NOUN", region="lbx")
+        syl = "-".join(info["syllables"]) or "(unknown)"
+        ipa = info["phonemes"] or "(unknown)"
+        print(f"{word:12} {syl:18} /{ipa}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_postag_homographs.py
+++ b/examples/02_postag_homographs.py
@@ -1,0 +1,27 @@
+"""Example — part-of-speech changes the pronunciation (heterophonic homographs).
+
+Run::
+
+    python examples/02_postag_homographs.py
+"""
+from tugalex import TugaLexicon
+
+
+def main() -> None:
+    lex = TugaLexicon()
+
+    # "acordo" is the noun "an accord" or the verb "I wake up" — different vowel.
+    print("acordo as NOUN:", lex.get_phonemes("acordo", pos="NOUN"))
+    print("acordo as VERB:", lex.get_phonemes("acordo", pos="VERB"))
+    print("postags for acordo:", lex.possible_postags.get("acordo"))
+    print()
+
+    # A few words straight from the homograph table, every variant they carry.
+    for word in ["para", "pelo", "seco"]:
+        variants = lex.homographs.get(word, {})
+        rendered = ", ".join(f"{pos}=/{ipa}/" for pos, ipa in variants.items())
+        print(f"{word:8} {rendered}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_dialects.py
+++ b/examples/03_dialects.py
@@ -1,0 +1,27 @@
+"""Example — the same word across Portuguese dialects.
+
+Run::
+
+    python examples/03_dialects.py
+"""
+from tugalex import TugaLexicon
+
+
+def main() -> None:
+    lex = TugaLexicon()
+
+    dialects = ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]
+    word = "acordo"
+
+    print(f"phonemes of {word!r} (NOUN) by dialect:")
+    for iso in dialects:
+        region = lex.lang_to_region(iso)
+        ipa = lex.get_phonemes(word, pos="NOUN", region=region)
+        print(f"  {iso} ({region}): {ipa or '(no entry)'}")
+
+    print()
+    print("all region codes in the dataset:", sorted(lex.regions))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_ao1990.py
+++ b/examples/04_ao1990.py
@@ -1,0 +1,28 @@
+"""Example — convert spelling across the AO1990 orthographic agreement.
+
+Run::
+
+    python examples/04_ao1990.py
+"""
+from tugalex import TugaLexicon
+
+
+def main() -> None:
+    lex = TugaLexicon()
+
+    old = "acção óptimo"
+    modern = lex.normalize_ao1900(old)
+    print(f"old    : {old}")
+    print(f"modern : {modern}")
+    print()
+
+    # Reverse modern spelling back to each pre-agreement standard.
+    print("revert 'ótimo' to PT-PT:", lex.reverse_ao1900_pt("ótimo"))
+    print("revert 'ato'   to PT-BR:", lex.reverse_ao1900_br("ato"))
+    print()
+
+    print("AO1990 entries loaded:", len(lex.AO1990))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_phenomena.py
+++ b/examples/05_phenomena.py
@@ -1,0 +1,29 @@
+"""Example — archaisms, silent 'p', and the formerly-trema voiced 'u'.
+
+Run::
+
+    python examples/05_phenomena.py
+"""
+from tugalex import TugaLexicon
+
+
+def main() -> None:
+    lex = TugaLexicon()
+
+    # Archaic spellings are rewritten to their modern form on lookup.
+    print("archaisms (old -> modern):")
+    for old in ["architecto", "pharmacia", "caballo"]:
+        modern = lex.archaic_words.get(old, "(unmapped)")
+        ipa = lex.get_phonemes(old)
+        print(f"  {old:12} -> {modern:12} /{ipa}/")
+    print()
+
+    print(f"silent-p words: {len(lex.silent_p_words)}")
+    print("  e.g.", sorted(lex.silent_p_words)[:4])
+
+    print(f"voiced-u words: {len(lex.voiced_u_words)}")
+    print("  e.g.", sorted(lex.voiced_u_words)[:4])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_g2p_map.py
+++ b/examples/06_g2p_map.py
@@ -1,0 +1,25 @@
+"""Example — build a flat grapheme-to-phoneme map for a model front-end.
+
+Run::
+
+    python examples/06_g2p_map.py
+"""
+from tugalex import TugaLexicon
+
+
+def main() -> None:
+    lex = TugaLexicon()
+
+    g2p = lex.get_ipa_map(pos="NOUN", region="lbx")
+    print(f"NOUN g2p entries: {len(g2p)}")
+
+    # Transcribe a small inline sentence, word by word, falling back gracefully.
+    sentence = "o acordo da casa"
+    print(f"\ntranscribing: {sentence!r}")
+    for word in sentence.split():
+        ipa = g2p.get(word) or lex.get_phonemes(word, pos="NOUN") or "?"
+        print(f"  {word:8} -> /{ipa}/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a docs/ guide and runnable examples for TugaLexicon.

## docs/
- quickstart.md — install, the single-class core idea, first lookup, POS, dialects, AO1990
- api.md — every public method, kwarg, and return shape (get, get_phonemes, get_syllables, get_wordlist, get_ipa_map, lang_to_region, the AO1990 conversions, and the cached views)
- advanced.md — G2P map building, homograph resolution, archaism folding, orthography round-trips, phenomena detection, and gotchas

## examples/
- 01_lookup.py — phonemes and syllables for Portuguese words
- 02_postag_homographs.py — POS changes the pronunciation
- 03_dialects.py — same word across pt-PT/BR/AO/MZ/TL
- 04_ao1990.py — normalize and reverse AO1990 spelling
- 05_phenomena.py — archaisms, silent-p, voiced-u sets
- 06_g2p_map.py — flat grapheme-to-phoneme map for a front-end

All six examples run against the packaged data and exit 0.