### PR TITLE
feat: AO1990 word-map additions + fix from portuguesaletra.com cross-check

### DIFF
--- a/tugalex/data/acordo_ortografico_pt_BR.csv
+++ b/tugalex/data/acordo_ortografico_pt_BR.csv
@@ -2057,3 +2057,16 @@ zôo,zoo
 zoofitóide,zoofitoide
 zoogléia,zoogleia
 zoóide,zooide
+pára-choques,para-choques
+dactilozóide,dactilozoide
+amidalóide,amidaloide
+co-fator,cofator
+co-ocorrência,coocorrência
+co-ocorrente,coocorrente
+co-ocupante,coocupante
+co-organizado,coorganizado
+co-opositor,coopositor
+anti-retroviral,antirretroviral
+semi-reto,semirreto
+semi-reta,semirreta
+contra-reação,contrarreação

--- a/tugalex/data/acordo_ortografico_pt_PT.csv
+++ b/tugalex/data/acordo_ortografico_pt_PT.csv
@@ -2410,7 +2410,7 @@ perfeccional,"perfecional, perfeccional"
 perfeccionismo,"perfecionismo, perfeccionismo"
 perfeccionista,"perfecionista, perfeccionista"
 perfeccionístico,"perfecionístico, perfeccionístico"
-perfectibilidade,"perfetibilidade, perfetibilidade"
+perfectibilidade,perfetibilidade
 perfectibilismo,"perfetibilismo, perfectibilismo"
 perfectibilista,"perfetibilista, perfectibilista"
 perfectibilizar,"perfetibilizar, perfectibilizar"
@@ -3264,3 +3264,6 @@ zoofitóide,zoofitoide
 zoóide,zooide
 zoóptico,zoótico
 zootáctico,zootático
+amigdalóide,amigdaloide
+pólo,polo
+busca-pólos,busca-polos


### PR DESCRIPTION
Cross-checks the AO1990 PT/BR word maps against an independent authority — the lexicon scraped from [portuguesaletra.com](https://portuguesaletra.com/category/acordo-ortografico/), now published at [TigreGotico/acordo-ortografico-lexicon](https://huggingface.co/datasets/TigreGotico/acordo-ortografico-lexicon).

**Validation:** the maps are already comprehensive — a converter built on them reproduced the authority on **2009/2009** pre→post pairs. This PR contributes only the small verified delta.

**Changes**
- **Fix** `perfectibilidade`: new_form was a doubled value (`perfetibilidade, perfetibilidade` → `perfetibilidade`).
- **Add 16** high-confidence, rule-verifiable pairs the maps lacked — paroxytone `-óide` drops, AO1990 prefix-hyphen rules (`co-`/`anti-`/`semi-`/`contra-`), and the differential accent (`pólo→polo`).

Only mechanically-certain pairs are included; noisier auto-extracted candidates (reversed pairs, PT/BR divergences, oxytone accents) were deliberately excluded. Draft for review.

Note: the maps carry a few pre-existing duplicate `old_form` keys — flagged for a separate cleanup.