### PR TITLE
fix(packaging): ship regional_dict.csv.gz in wheels and sdists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ where = ["."]
 include = ["tugalex*"]
 
 [tool.setuptools.package-data]
-tugalex = ["data/*.csv"]
+tugalex = ["data/*.csv", "data/*.csv.gz"]
 
 [tool.setuptools.dynamic]
 version = { attr = "tugalex.version.VERSION_STR" }


### PR DESCRIPTION
2.0.0a1 wheels/sdists shipped WITHOUT the regional dictionary: the `[tool.setuptools.package-data]` glob `data/*.csv` doesn't match `regional_dict.csv.gz`, so `TugaLexicon()` raised `FileNotFoundError` from any installed distribution (caught by the tugaphone adaptation run; 1.0.0a1 was equally affected). Glob extended to `data/*.csv.gz`; wheel contents verified locally.

Note: a stale remote branch named `fix` blocks the `fix/*` branch namespace, hence the `bugfix/` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)