### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# TugaLex 🗣️
+# TugaLex
 
-**TugaLex** is a comprehensive lexicon handler and linguistic utility for Portuguese dialects. It provides deep data on phoneme transcription (IPA), syllable segmentation, and historical/modern orthographic rules.
+**TugaLex** is a lexicon handler and linguistic utility for Portuguese dialects. It provides data on phoneme transcription (IPA), syllable segmentation, and historical and modern orthographic rules.
 
-Designed for NLP pipelines and linguistics research, it allows you to handle the complexities of Portuguese across different regions and historical agreements with a unified API.
+It gives NLP pipelines and linguistics research a single API for the differences between Portuguese regions and historical spelling agreements.
 
 ---
 
-## 🌍 Supported Dialects
+## Supported Dialects
 
 TugaLex maps standard ISO codes to internal regional datasets:
 
@@ -14,20 +14,20 @@ TugaLex maps standard ISO codes to internal regional datasets:
 | --- | --- | --- |
 | `pt-PT` | `lbx` | Portugal (Lisbon) |
 | `pt-BR` | `rjx` | Brazil (Rio de Janeiro) |
-| — | `spx` | Brazil (São Paulo) |
+| n/a | `spx` | Brazil (São Paulo) |
 | `pt-AO` | `lda` | Angola (Luanda) |
 | `pt-MZ` | `mpx` | Mozambique (Maputo) |
 | `pt-TL` | `dli` | Timor-Leste (Díli) |
 
 The regional dictionary ships as a slim gzip extract (word, POS, phones,
-syllables, region) of the [unified Portuguese pronunciation lexicon](https://huggingface.co/datasets/TigreGotico/portuguese-unified-pronunciation-lexicon),
-regenerated with `python scripts/build_regional_dict.py`. Words whose
+syllables, region) of the [unified Portuguese pronunciation lexicon](https://huggingface.co/datasets/TigreGotico/portuguese-unified-pronunciation-lexicon).
+Regenerate it with `python scripts/build_regional_dict.py`. Words whose
 pronunciation does not vary by part of speech carry a single POS-invariant
 entry that answers every POS query.
 
 ---
 
-## ✨ Key Features
+## Key Features
 
 ### 1. Phonemes & Syllables
 
@@ -52,10 +52,10 @@ verb_phonemes = lex.get_phonemes("acordo", pos="NOUN")
 
 ### 2. Orthographic Agreement (AO1990)
 
-Effortlessly convert text between pre-agreement and post-agreement (AO1990) standards for both Portugal and Brazil.
+Convert text between pre-agreement and post-agreement (AO1990) spelling for Portugal and Brazil.
 
-* **Normalize:** Old spelling → Modern spelling.
-* **Reverse:** Modern spelling → Old regional spelling (PT or BR).
+* **Normalize:** Old spelling to modern spelling.
+* **Reverse:** Modern spelling to old regional spelling (PT or BR).
 
 ```python
 normalized = lex.normalize_ao1900(sentence)
@@ -72,12 +72,39 @@ TugaLex identifies specific linguistic phenomena programmatically:
 
 ---
 
-## 📂 Datasets
+## Datasets
 
-TugaLex ships the following datasets which contain over 100,000 entries sourced from the [Portal da Língua Portuguesa](http://www.portaldalinguaportuguesa.org).
+TugaLex ships the following datasets. Together they contain over 100,000 entries sourced from the [Portal da Língua Portuguesa](http://www.portaldalinguaportuguesa.org).
 
 * [`regional_dict.csv`](https://huggingface.co/datasets/TigreGotico/portuguese_phonetic_lexicon): Phoneme and syllable mappings.
 * [`heterophonic_homographs.csv`](https://huggingface.co/datasets/TigreGotico/heterophonic_homographs_pt): words pronounced differently depending on postag.
 * [`acordo_ortografico_pt_PT.csv`](https://huggingface.co/datasets/TigreGotico/AO1990_pt-PT): Portugal old orthographic spellings.
 * [`acordo_ortografico_pt_BR.csv`](https://huggingface.co/datasets/TigreGotico/AO1990_pt-BR): Brazil old orthographic spellings.
 * [`archaisms.csv`](https://huggingface.co/datasets/TigreGotico/archaisms_pt): normalized words from before the 20th century.
+
+---
+
+## Install
+
+```bash
+pip install -e .
+```
+
+TugaLex has no third-party runtime dependencies. All datasets ship inside the package under `tugalex/data/`.
+
+---
+
+## Related Projects
+
+TugaLex is one piece of the TigreGotico Portuguese NLP stack:
+
+* [tugaphone](https://github.com/TigreGotico/tugaphone): phonemizes arbitrary Portuguese text across dialects, using TugaLex plus a rule-based fallback.
+* [tugamorph](https://github.com/TigreGotico/tugamorph): rule-based morphological analyzer for Portuguese.
+* [tugatagger](https://github.com/TigreGotico/tugatagger): Part-of-Speech tagging wrapper for Portuguese.
+* [desacordo_ortografico](https://github.com/TigreGotico/desacordo_ortografico): detects and converts between Portuguese orthographies, including the AO1990 reform.
+
+---
+
+## License
+
+TugaLex is released under the [Apache License 2.0](LICENSE).

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -6,7 +6,7 @@ and the packaged data.
 ## Build a grapheme-to-phoneme map for a model
 
 `get_ipa_map()` hands you a flat `{word: phonemes}` dictionary for one POS and
-region — exactly the shape a G2P training step or a TTS front-end wants.
+region. This is exactly the shape a G2P training step or a TTS front-end wants.
 
 ```python
 from tugalex import TugaLexicon
@@ -17,7 +17,7 @@ verbs = lex.get_ipa_map(pos="VERB", region="lbx")
 print(len(nouns), len(verbs))   # tens of thousands each
 ```
 
-Need every POS for every word? Walk `possible_postags`:
+To get every POS for every word, walk `possible_postags`:
 
 ```python
 for word, tags in list(lex.possible_postags.items())[:5]:
@@ -27,7 +27,7 @@ for word, tags in list(lex.possible_postags.items())[:5]:
 
 ## Resolve homographs correctly
 
-A homograph carries a different transcription per POS, and the homograph table is
+A homograph carries a different transcription per POS. The homograph table is
 consulted before the regional dictionary. Always pass the POS you mean:
 
 ```python
@@ -35,12 +35,12 @@ lex.get_phonemes("para", pos="ADP")    # ˈpɐɾɐ  (the preposition "for")
 lex.get_phonemes("para", pos="VERB")   # ˈpaɾɐ  (he/she stops)
 ```
 
-The full table is `lex.homographs` — `{word: {POS: ipa}}`.
+The full table is `lex.homographs`, shaped as `{word: {POS: ipa}}`.
 
 ## Archaisms fold into pronunciation automatically
 
-When you ask for the phonemes of a pre-20th-century spelling, it is rewritten to
-its modern form first, so you still get a transcription:
+When you ask for the phonemes of a pre-20th-century spelling, TugaLex rewrites
+it to its modern form first, so you still get a transcription:
 
 ```python
 lex.archaic_words["pharmacia"]      # 'farmácia'
@@ -49,16 +49,17 @@ lex.get_phonemes("architecto")      # 'ɐɾ·ki·tˈɛ·tu'  (looked up as arqui
 
 ## Round-trip orthography across the AO1990 agreement
 
-`normalize_ao1900()` goes old → modern; the two `reverse_*` methods go modern →
-old for each standard. Unmapped words pass through, so whole sentences are safe.
+`normalize_ao1900()` goes from old to modern spelling. The two `reverse_*`
+methods go from modern back to old, one per standard. Unmapped words pass
+through, so whole sentences are safe.
 
 ```python
 modern = lex.normalize_ao1900("acção óptimo")   # 'ação ótimo'
 back_pt = lex.reverse_ao1900_pt("ótimo")         # 'óptimo'
 ```
 
-PT and BR diverge: a word can revert differently per standard, which is why there
-are two reverse methods rather than one.
+PT and BR diverge. A word can revert differently per standard, which is why
+there are two reverse methods instead of one.
 
 ## Detect spelling phenomena
 
@@ -75,21 +76,19 @@ spell-checking pipeline.
 ## Gotchas
 
 - **POS casing.** Lookups expect uppercase tags (`NOUN`, `VERB`, `ADJ`, `ADP`).
-  A lowercase tag silently misses and you get `None`.
+  A lowercase tag silently misses and returns `None`.
 - **Unknown words return falsy, they do not raise.** `get_phonemes` returns
   `None` and `get_syllables` returns `[]` for words not in the dataset. An
   unsupported *region*, by contrast, raises `ValueError` from `get_syllables`,
   `get_wordlist`, `get_ipa_map`, and `lang_to_region`.
 - **First touch is slow.** The first access to `ipa`, `syllables`, `regions`, or
-  any method that uses them parses the large CSV. Construct one `TugaLexicon` and
-  reuse it across calls.
+  any method that uses them parses the large CSV. Construct one `TugaLexicon`
+  and reuse it across calls.
 - **More regions than the five public dialects.** `lex.regions` also contains
   internal codes such as `rjo`, `lbn`, `spx`, `map`, `spo`. Only the five in
-  `lang_to_region` have ISO aliases; the rest are reachable by raw `region=`.
-- **Method names read `1900`.** `normalize_ao1900` / `reverse_ao1900_pt` /
-  `reverse_ao1900_br` implement the AO1990 agreement.
+  `lang_to_region` have ISO aliases. Reach the rest with a raw `region=` value.
+- **Method names read `1900`.** `normalize_ao1900`, `reverse_ao1900_pt`, and
+  `reverse_ao1900_br` all implement the AO1990 agreement.
 
-## Where next
-
-- [quickstart.md](quickstart.md) — install and the core idea
-- [api.md](api.md) — full signatures and return shapes
+---
+[← API reference](api.md) · [Home](../README.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,8 +13,8 @@ from tugalex import TugaLexicon
 | `dictionary_path` | `Optional[str]` | `None` | Path to a regional CSV. `None` uses the packaged `data/regional_dict.csv`. |
 
 Construction loads the small CSVs eagerly (AO1990 PT/BR, homographs, archaisms).
-The large `regional_dict.csv` is loaded lazily on first access to phonemes,
-syllables, or regions, then cached on the instance.
+The large `regional_dict.csv` loads lazily on first access to phonemes,
+syllables, or regions, then it is cached on the instance.
 
 ### Region codes
 
@@ -28,9 +28,9 @@ ISO dialect codes map to internal region codes through `lang_to_region()`:
 | `pt-MZ` | `mpx` |
 | `pt-TL` | `dli` |
 
-The dataset itself carries more regions than the five mapped above (for example
-`rjo`, `lbn`, `spx`, `map`, `spo`); inspect `lex.regions` for the full set. Pass
-any of those raw codes as `region=`.
+The dataset carries more regions than the five mapped above (for example
+`rjo`, `lbn`, `spx`, `map`, `spo`). Inspect `lex.regions` for the full set.
+Pass any of those raw codes as `region=`.
 
 ## Lookup methods
 
@@ -51,10 +51,10 @@ Returns a dict with keys `"syllables"` (`List[str]`, empty if unknown) and
 The IPA transcription, or `None` when there is no entry. Matching is
 case-insensitive. Lookup order:
 
-1. If the word is an archaism, it is first rewritten to its modern form.
+1. If the word is an archaism, TugaLex first rewrites it to its modern form.
 2. If the word is a heterophonic homograph with an entry for `pos`, that
    pronunciation wins (homographs are region-independent).
-3. Otherwise the regional dictionary is consulted for `region` + `pos`.
+3. Otherwise TugaLex consults the regional dictionary for `region` and `pos`.
 
 ```python
 lex.get_phonemes("acordo", pos="NOUN")   # 'ɐˈkoɾdu'
@@ -64,8 +64,8 @@ lex.get_phonemes("architecto")           # 'ɐɾ·ki·tˈɛ·tu'  (archaism -> a
 
 ### `get_syllables(word, region="lbx") -> List[str]`
 
-Syllable segments for the word; empty list if unknown. Raises `ValueError` if
-`region` is not in the loaded dataset.
+Syllable segments for the word, or an empty list if unknown. Raises
+`ValueError` if `region` is not in the loaded dataset.
 
 ```python
 lex.get_syllables("casa")    # ['ca', 'sa']
@@ -83,7 +83,8 @@ len(lex.get_wordlist("lbx"))   # 53349
 ### `get_ipa_map(pos="NOUN", region="lbx") -> Dict[str, str]`
 
 A flat `{word: phonemes}` map for one POS and region, merging the regional
-dictionary with the homograph table. Raises `ValueError` for an unknown region.
+dictionary with the homograph table. Raises `ValueError` for an unknown
+region.
 
 ```python
 g2p = lex.get_ipa_map(pos="NOUN")
@@ -104,7 +105,7 @@ lex.lang_to_region("pt-BR")   # 'rjx'
 
 ### `normalize_ao1900(sentence) -> str`
 
-Rewrite each word to its modern AO1990 spelling; unknown words pass through.
+Rewrite each word to its modern AO1990 spelling. Unknown words pass through.
 
 ```python
 lex.normalize_ao1900("acção óptimo")   # 'ação ótimo'
@@ -136,7 +137,7 @@ lex.reverse_ao1900_br("ato")   # 'ato'
 | `homographs` | `Dict[word, Dict[POS, str]]` | POS-dependent pronunciations. |
 | `archaic_words` | `Dict[old, new]` | Pre-20th-century spelling to modern. |
 | `possible_postags` | `Dict[word, List[str]]` | POS tags available per word (cached). |
-| `AO1990` | `Dict[old, List[str]]` | Combined PT + BR old→new spelling map (cached). |
+| `AO1990` | `Dict[old, List[str]]` | Combined PT + BR old-to-new spelling map (cached). |
 | `silent_p_words` | `Set[str]` | Words with a silent `p` (`mpc`/`mpç`/`mpt` clusters) (cached). |
 | `voiced_u_words` | `Set[str]` | Words where `u` is voiced in `gue`/`gui`/`que`/`qui` (former trema) (cached). |
 
@@ -148,7 +149,5 @@ len(lex.voiced_u_words)        # 283
 lex.possible_postags["acordo"] # ['NOUN', 'VERB']
 ```
 
-## Where next
-
-- [quickstart.md](quickstart.md) — install and first calls
-- [advanced.md](advanced.md) — recipes, gotchas, integration
+---
+[← Quickstart](quickstart.md) · [Home](../README.md) · [Advanced →](advanced.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,10 @@
-# Quickstart — zero to hero
+# Quickstart
 
-`tugalex` is a lexicon handler for Portuguese dialects. One class, `TugaLexicon`,
-answers three kinds of question about a Portuguese word: how is it pronounced
-(IPA), how does it break into syllables, and how does it spell across the AO1990
-orthographic agreement. All data ships in the package as CSV — no network, no
-model files, no API keys.
+`tugalex` is a lexicon handler for Portuguese dialects. One class,
+`TugaLexicon`, answers three kinds of question about a Portuguese word: how is
+it pronounced (IPA), how does it break into syllables, and how does it spell
+across the AO1990 orthographic agreement. All data ships in the package as
+CSV. There is no network access, no model files, and no API keys.
 
 ## 1. Install
 
@@ -13,13 +13,13 @@ pip install -e .
 ```
 
 There are no third-party runtime dependencies. The datasets live under
-`tugalex/data/`; `regional_dict.csv` is the large one (~49 MB) and loads lazily
-the first time you touch phonemes, syllables, or regions.
+`tugalex/data/`. `regional_dict.csv` is the large one (about 49 MB) and loads
+lazily the first time you touch phonemes, syllables, or regions.
 
 ## 2. The one thing to understand
 
-Everything hangs off a single object. Construct it once and reuse it — the heavy
-CSV is parsed on first access and cached on the instance.
+Everything hangs off a single object. Construct it once and reuse it. The
+heavy CSV is parsed on first access and cached on the instance.
 
 ```python
 from tugalex import TugaLexicon
@@ -30,14 +30,15 @@ info = lex.get("acordo", pos="NOUN", region="lbx")
 print(info)   # {'syllables': ['a', 'cor', 'do'], 'phonemes': 'ɐˈkoɾdu'}
 ```
 
-`get()` is the convenience call. Under it sit two focused lookups —
-`get_syllables()` and `get_phonemes()` — which you can call directly when you
+`get()` is the convenience call. Under it sit two focused lookups,
+`get_syllables()` and `get_phonemes()`, which you can call directly when you
 only need one half.
 
 ## 3. Part-of-speech matters
 
-Portuguese has heterophonic homographs: same spelling, different sound depending
-on the grammatical role. Pass the right `pos` and you get the right vowel.
+Portuguese has heterophonic homographs: same spelling, different sound
+depending on the grammatical role. Pass the right `pos` and you get the right
+vowel.
 
 ```python
 print(lex.get_phonemes("acordo", pos="NOUN"))   # ɐˈkoɾdu  (the noun: an accord)
@@ -46,12 +47,12 @@ print(lex.get_phonemes("acordo", pos="VERB"))   # ɐˈkɔɾdu  (the verb: I wake
 
 POS tags are uppercase Universal-Dependencies style: `NOUN`, `VERB`, `ADJ`,
 `ADP`, and so on. Ask a word which tags it carries with
-`lex.possible_postags["acordo"]` → `['NOUN', 'VERB']`.
+`lex.possible_postags["acordo"]`, which returns `['NOUN', 'VERB']`.
 
 ## 4. Pick a dialect
 
-The dataset is region-indexed. Public ISO dialect codes map to internal region
-codes via `lang_to_region()`:
+The dataset is region-indexed. Public ISO dialect codes map to internal
+region codes through `lang_to_region()`:
 
 ```python
 lex.lang_to_region("pt-PT")   # 'lbx'  (Portugal)
@@ -77,15 +78,13 @@ lex.get_phonemes("acordo", pos="NOUN", region="rjx")
 Convert between pre-agreement and modern spelling in both directions:
 
 ```python
-lex.normalize_ao1900("acção óptimo")    # 'ação ótimo'   (old -> modern)
-lex.reverse_ao1900_pt("ótimo")          # 'óptimo'        (modern -> old PT-PT)
-lex.reverse_ao1900_br("ato")            # 'ato'           (modern -> old PT-BR)
+lex.normalize_ao1900("acção óptimo")    # 'ação ótimo'   (old to modern)
+lex.reverse_ao1900_pt("ótimo")          # 'óptimo'        (modern to old PT-PT)
+lex.reverse_ao1900_br("ato")            # 'ato'           (modern to old PT-BR)
 ```
 
 Words with no mapping pass through unchanged, so it is safe to run on whole
 sentences.
 
-## Where next
-
-- [api.md](api.md) — every public class, method, kwarg, and return shape
-- [advanced.md](advanced.md) — recipes, gotchas, building grapheme-to-phoneme maps
+---
+[Home](../README.md) · [API reference →](api.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md for clarity: shorter sentences, active voice, no marketing adjectives, no emoji, and consistent terminology. Adds Install, Related Projects, and License sections to the README from existing facts in pyproject.toml and LICENSE. Adds the standard prev/home/next footer navigation to the three docs pages.

Rewritten with Claude Fable 5 using the ste-writing skill; linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and refreshed the README and documentation pages for improved readability.
  * Clarified supported dialects, ISO-code mappings, datasets, and runtime dependency information.
  * Refined guidance for phoneme lookup, part-of-speech handling, regional dictionaries, and orthographic conversion.
  * Updated examples, wording, formatting, and navigation links across the quickstart and advanced guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->